### PR TITLE
Add error.xml profile

### DIFF
--- a/error.xml
+++ b/error.xml
@@ -1,0 +1,29 @@
+<alps version="1.0">
+    <descriptor id="error" type="semantic">
+        <doc>Error Message</doc>
+ 
+        <descriptor id="message" type="semantic">
+            <doc>
+                For expressing a human readable message related to the current error which may be displayed to the user of the api
+            </doc>
+        </descriptor>
+ 
+        <descriptor id="logref" type="semantic">
+            <doc>
+                For expressing an identifier to refer to the specific error on the server side for logging purposes
+            </doc>
+        </descriptor>
+ 
+        <descriptor id="help" type="safe" def="http://www.w3.org/TR/html5/links.html#link-type-help">
+            <doc>
+                Link to a help document describing the error
+            </doc>
+        </descriptor>
+ 
+        <descriptor id="describes" type="safe" def="RFC6892">
+            <doc>
+                Link to another representation of this error
+            </doc>
+        </descriptor>
+    </descriptor>
+</alps>


### PR DESCRIPTION
This profile is for abstracting the semantics and links from the vnd.error media type for use in other formats.

I noticed in the [maze-alps](https://github.com/alps-io/profiles/blob/master/maze-alps.xml) profile, there was a `def` attribute used to point to documentation on the semantic or link. I went ahead and used this, though I'll be happy to change it if there is a more preferred way of doing so.
